### PR TITLE
自動更新機能１

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -3,7 +3,7 @@ $(function(){
     
     if (message.image) {
       var html = 
-        `<div class="message">
+        `<div class="message" data-message-id=${message.id}>
            <div class="message__list-info">
              <p class="message__list-info__name">
                ${message.user_name}
@@ -22,7 +22,7 @@ $(function(){
       return html;
     } else {
       var html = 
-       `<div class="message">
+       `<div class="message" data-message-id=${message.id}>
           <div class="message__list-info">
             <p class="message__list-info__name">
               ${message.user_name}
@@ -41,7 +41,7 @@ $(function(){
     
   }
 
-
+  
 
   $('#new_message').on('submit', function(e){
     e.preventDefault();
@@ -67,4 +67,36 @@ $(function(){
       $('form')[0].reset();
     })
   });
+  var reloadMessages = function() {
+    //カスタムデータ属性を利用し、ブラウザに表示されている最新メッセージのidを取得
+    var last_message_id = $('.message:last').data("message-id");
+    $.ajax({
+      //ルーティングで設定した通り/groups/id番号/api/messagesとなるよう文字列を書く
+      url: "api/messages",
+      //ルーティングで設定した通りhttpメソッドをgetに指定
+      type: 'get',
+      dataType: 'json',
+      //dataオプションでリクエストに値を含める
+      data: {id: last_message_id}
+    })
+    .done(function(messages) {
+      if (messages.length !== 0) {
+        //追加するHTMLの入れ物を作る
+        var insertHTML = '';
+        //配列messagesの中身一つ一つを取り出し、HTMLに変換したものを入れ物に足し合わせる
+        $.each(messages, function(i, message) {
+          insertHTML += buildHTML(message)
+        });
+        //メッセージが入ったHTMLに、入れ物ごと追加
+        $('.messages').append(insertHTML);
+        $('.messages').animate({ scrollTop: $('.messages')[0].scrollHeight});
+      }
+    })
+    .fail(function() {
+      alert('error');
+    });
+  };
+  if (document.location.href.match(/\/groups\/\d+\/messages/)) {
+    setInterval(reloadMessages, 7000);
+  }
 });

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,12 @@
+class Api::MessagesController < ApplicationController
+  ##::名前空間(namespace),同じ苗字の人を部署名をつけて呼ぶみたいなもの
+  
+  def index
+    # ルーティングでの設定によりparamsの中にgroup_idというキーでグループのidが入るので、これを元にDBからグループを取得する
+    group = Group.find(params[:group_id])
+    # ajaxで送られてくる最後のメッセージのid番号を変数に代入
+    last_message_id = params[:id].to_i
+    # 取得したグループでのメッセージ達から、idがlast_message_idよりも新しい(大きい)メッセージ達のみを取得
+    @messages = group.messages.includes(:user).where("id > ?", last_message_id)
+  end
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,8 @@
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image.url
+  json.created_at message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  json.user_name message.user.name
+  json.id message.id
+end
+

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.message
+.message{data: {message: {id: message.id}}}
   .message__list-info
     %p.message__list-info__name
       = message.user.name 

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -2,3 +2,4 @@ json.user_name @message.user.name
 json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
 json.content @message.content
 json.image @message.image_url
+json.id @message.id


### PR DESCRIPTION
#What
chat-space自動更新機能の実装。

#Why
投稿者は投稿内容が非同期で画面に表示されるが、別ユーザーは投稿メッセージをリロードしなければ表示されない。なので、投稿者以外も同グループメンバーが手間をかけず自動でチャット画面が更新されるようにするため。

[https://gyazo.com/0a9683d268e1974178a46206ed887fe0](url)